### PR TITLE
fix: remove 'postinstall' and 'postpack' scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
   "scripts": {
     "cm": "cz",
     "lint": "eslint --max-warnings=0 --fix",
-    "prepack": "pinst --disable",
     "prettify": "prettier --write",
-    "postpack": "pinst --enable",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
# Fixes errors when trying to run `npm publish`

- Removes `postinstall` and `postpack` at `package.json`
